### PR TITLE
Allow last provisioned host to affect configuration

### DIFF
--- a/lib/gru/adapters/redis_adapter.rb
+++ b/lib/gru/adapters/redis_adapter.rb
@@ -79,19 +79,19 @@ module Gru
       end
 
       def register_worker(worker,count)
-        send_message(:hsetnx,"#{host_key}:workers_running",worker,count)
+        send_message(:hset,"#{host_key}:workers_running",worker,count)
       end
 
       def register_global_worker(worker,count)
-        send_message(:hsetnx,"#{global_key}:workers_running",worker,count)
+        send_message(:hset,"#{global_key}:workers_running",worker,count)
       end
 
       def set_max_worker_count(worker,count)
-        send_message(:hsetnx,"#{host_key}:max_workers",worker,count)
+        send_message(:hset,"#{host_key}:max_workers",worker,count)
       end
 
       def set_max_global_worker_count(worker,count)
-        send_message(:hsetnx,"#{global_key}:max_workers",worker,count)
+        send_message(:hset,"#{global_key}:max_workers",worker,count)
       end
 
       def reserve_worker(worker)

--- a/lib/gru/worker_manager.rb
+++ b/lib/gru/worker_manager.rb
@@ -46,9 +46,5 @@ module Gru
       @adapter.release_workers
     end
 
-    def cleanup
-      @adapter.cleanup
-    end
-
   end
 end

--- a/spec/gru/adapters/redis_adapter_spec.rb
+++ b/spec/gru/adapters/redis_adapter_spec.rb
@@ -28,17 +28,17 @@ describe Gru::Adapters::RedisAdapter do
     end
 
     it "registers workers" do
-      expect(client).to receive(:hsetnx).with("GRU:#{hostname}:workers_running",'test_worker',0)
+      expect(client).to receive(:hset).with("GRU:#{hostname}:workers_running",'test_worker',0)
       adapter.send(:register_workers,workers)
     end
 
     it "sets worker counts" do
-      expect(client).to receive(:hsetnx).with("GRU:#{hostname}:max_workers",'test_worker',3)
+      expect(client).to receive(:hset).with("GRU:#{hostname}:max_workers",'test_worker',3)
       adapter.send(:set_max_worker_counts,workers)
     end
 
     it "sets global worker counts" do
-      expect(client).to receive(:hsetnx).with("GRU:global:max_workers",'test_worker',3)
+      expect(client).to receive(:hset).with("GRU:global:max_workers",'test_worker',3)
       adapter.send(:set_max_global_worker_counts,workers)
     end
 


### PR DESCRIPTION
This will allow hosts provisioned subsequently to affect global
configuation.
