### PR TITLE
Cleanup orphaned worker state on startup

### DIFF
--- a/lib/gru/adapters/redis_adapter.rb
+++ b/lib/gru/adapters/redis_adapter.rb
@@ -12,6 +12,7 @@ module Gru
 
       def set_worker_counts
         set_rebalance_flag(@settings.rebalance_flag)
+        release_workers
         register_workers(@settings.host_maximums)
         set_max_worker_counts(@settings.host_maximums)
         register_global_workers(@settings.cluster_maximums)

--- a/lib/gru/version.rb
+++ b/lib/gru/version.rb
@@ -1,3 +1,3 @@
 module Gru
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
This allows gru to cleanup worker counts if reconnecting after a redis
timeout.
