### PR TITLE
Update provision and expire checks

### DIFF
--- a/lib/gru/version.rb
+++ b/lib/gru/version.rb
@@ -1,3 +1,3 @@
 module Gru
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/gru/gru_integration_spec.rb
+++ b/spec/gru/gru_integration_spec.rb
@@ -8,7 +8,6 @@ require 'pry'
 # This requires a redis server instance running on localhost
 # un-pend to run with actual redis-server
 xdescribe Gru do
-
   after {
     client.flushdb
   }
@@ -166,6 +165,202 @@ xdescribe Gru do
       expect(test2.adjust_workers).to eq( { 'test_worker' => -3 })
       test_client.hset("GRU:default:default:heartbeats", 'test3', Time.now - 300)
       expect(test2.adjust_workers).to eq( { 'test_worker' => 3 })
+    end
+
+  end
+
+  context "max workers per host with high maximum worker count" do
+    let(:settings) {
+      {
+        rebalance_flag: true,
+        manage_worker_heartbeats: true,
+        max_workers_per_host: nil,
+        cluster_maximums: {
+        'test_worker' => '100'
+        }
+      }
+    }
+
+    let(:test_client) {
+      Redis.new
+    }
+
+    let(:adapter1) {
+      adapter1 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter1).to receive(:hostname).and_return('test1')
+      adapter1
+    }
+
+    let(:adapter2) {
+      adapter2 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter2).to receive(:hostname).and_return('test2')
+      adapter2
+    }
+
+    let(:adapter3) {
+      adapter3 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter3).to receive(:hostname).and_return('test3')
+      adapter3
+    }
+
+    let(:adapter4) {
+      adapter4 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter4).to receive(:hostname).and_return('test4')
+      adapter4
+    }
+
+    it "doesn't exceed max processes per host setting" do
+      test1 = Gru::WorkerManager.new(adapter1)
+      test2 = Gru::WorkerManager.new(adapter2)
+      test3 = Gru::WorkerManager.new(adapter3)
+      test1.register_workers
+      test2.register_workers
+      test3.register_workers
+      expect(test1.adjust_workers).to eq( { 'test_worker' => 30 })
+      expect(test2.adjust_workers).to eq( { 'test_worker' => 30 })
+      expect(test3.adjust_workers).to eq( { 'test_worker' => 30 })
+    end
+
+    it "honors the max processes per host setting and correctly rebalances worker counts" do
+      test1 = Gru::WorkerManager.new(adapter1)
+      test2 = Gru::WorkerManager.new(adapter2)
+      test3 = Gru::WorkerManager.new(adapter3)
+      test4 = Gru::WorkerManager.new(adapter4)
+      test1.register_workers
+      test2.register_workers
+      test3.register_workers
+      # Honors max processes per host setting
+      expect(test1.adjust_workers).to eq({ 'test_worker' => 30 })
+      expect(test2.adjust_workers).to eq({ 'test_worker' => 30 })
+      expect(test3.adjust_workers).to eq({ 'test_worker' => 30 })
+      test4.register_workers
+      # Pick up remaining workers
+      expect(test4.adjust_workers).to eq({ 'test_worker' => 10 })
+      # Rebalance workers across hosts
+      expect(test3.adjust_workers).to eq({ 'test_worker' => -5 })
+      expect(test2.adjust_workers).to eq({ 'test_worker' => -5 })
+      expect(test1.adjust_workers).to eq({ 'test_worker' => -5 })
+      expect(test4.adjust_workers).to eq({ 'test_worker' => 15 })
+      # No more workers to pick up on the hosts
+      expect(test4.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test3.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test2.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test1.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test4.adjust_workers).to eq({ 'test_worker' => 0 })
+      # Release workers
+      test4.release_workers
+      # Rebalance for lost host
+      expect(test1.adjust_workers).to eq({ 'test_worker' => 5 })
+      expect(test2.adjust_workers).to eq({ 'test_worker' => 5 })
+      expect(test3.adjust_workers).to eq({ 'test_worker' => 5 })
+      # No more workers due to max per host limit
+      expect(test1.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test2.adjust_workers).to eq({ 'test_worker' => 0 })
+      expect(test3.adjust_workers).to eq({ 'test_worker' => 0 })
+    end
+
+  end
+
+  context "max workers per host with high maximum worker count" do
+    let(:settings) {
+      {
+        rebalance_flag: true,
+        manage_worker_heartbeats: true,
+        max_workers_per_host: 5,
+        cluster_maximums: {
+        'test_worker1' => '3',
+        'test_worker2' => '3',
+        'test_worker3' => '3',
+        'test_worker4' => '3',
+        'test_worker5' => '3',
+        'test_worker6' => '3'
+        }
+      }
+    }
+
+    let(:test_client) {
+      Redis.new
+    }
+
+    let(:adapter1) {
+      adapter1 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter1).to receive(:hostname).and_return('test1')
+      adapter1
+    }
+
+    let(:adapter2) {
+      adapter2 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter2).to receive(:hostname).and_return('test2')
+      adapter2
+    }
+
+    let(:adapter3) {
+      adapter3 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter3).to receive(:hostname).and_return('test3')
+      adapter3
+    }
+
+    let(:adapter4) {
+      adapter4 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter4).to receive(:hostname).and_return('test4')
+      adapter4
+    }
+
+    it "handles many workers and few worker instances" do
+      test1 = Gru::WorkerManager.new(adapter1)
+      test2 = Gru::WorkerManager.new(adapter2)
+      test3 = Gru::WorkerManager.new(adapter3)
+      test4 = Gru::WorkerManager.new(adapter4)
+      test1.register_workers
+      test2.register_workers
+      test3.register_workers
+      # Honors max processes per host setting
+      expect(test1.adjust_workers).to eq({
+        'test_worker1' => 1,
+        'test_worker2' => 1,
+        'test_worker3' => 1,
+        'test_worker4' => 1,
+        'test_worker5' => 1,
+        'test_worker6' => 0
+      })
+
+      expect(test2.adjust_workers).to eq({
+        'test_worker1' => 1,
+        'test_worker2' => 1,
+        'test_worker3' => 1,
+        'test_worker4' => 1,
+        'test_worker5' => 1,
+        'test_worker6' => 0
+      })
+
+      expect(test3.adjust_workers).to eq({
+        'test_worker1' => 1,
+        'test_worker2' => 1,
+        'test_worker3' => 1,
+        'test_worker4' => 1,
+        'test_worker5' => 1,
+        'test_worker6' => 0
+      })
+      test4.register_workers
+      # Adds new worker based on new instance
+      expect(test4.adjust_workers).to eq({
+        'test_worker1' => 0,
+        'test_worker2' => 0,
+        'test_worker3' => 0,
+        'test_worker4' => 0,
+        'test_worker5' => 0,
+        'test_worker6' => 1
+      })
+
+      # Doesn't alter existing worker instances
+      expect(test1.adjust_workers).to eq({
+        'test_worker1' => 0,
+        'test_worker2' => 0,
+        'test_worker3' => 0,
+        'test_worker4' => 0,
+        'test_worker5' => 0,
+        'test_worker6' => 0
+      })
     end
   end
 end


### PR DESCRIPTION
These checks should compare the total number of workers running on a
host to the max_worker_processes_per_host setting.
