### PR TITLE
Remove stale worker keys from redis

### DIFF
--- a/lib/gru/adapters/redis_adapter.rb
+++ b/lib/gru/adapters/redis_adapter.rb
@@ -18,6 +18,7 @@ module Gru
         set_max_worker_counts(@settings.host_maximums)
         register_global_workers(@settings.cluster_maximums)
         set_max_global_worker_counts(@settings.cluster_maximums)
+        remove_stale_worker_entries
         update_heartbeat if manage_heartbeat?
       end
 
@@ -77,6 +78,13 @@ module Gru
           end
         end
         false
+      end
+
+      def remove_stale_worker_entries
+        stale_keys = max_global_workers.keys - @settings.cluster_maximums.keys
+        stale_keys.each do |key|
+          send_message(:hdel, global_max_worker_key, key)
+        end
       end
 
       private

--- a/lib/gru/version.rb
+++ b/lib/gru/version.rb
@@ -1,3 +1,3 @@
 module Gru
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/gru/gru_integration_spec.rb
+++ b/spec/gru/gru_integration_spec.rb
@@ -485,4 +485,34 @@ xdescribe Gru do
       })
     end
   end
+
+  context "Remove Stale Workers" do
+    let(:new_settings) {
+      {
+        cluster_maximums: {
+        'foo_worker' => '3'
+        }
+      }
+    }
+
+    let(:adapter1) {
+      adapter1 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(settings.clone))
+      allow(adapter1).to receive(:hostname).and_return('test1')
+      adapter1
+    }
+
+    let(:adapter2) {
+      adapter2 = Gru::Adapters::RedisAdapter.new(Gru::Configuration.new(new_settings.clone))
+      allow(adapter2).to receive(:hostname).and_return('test2')
+      adapter2
+    }
+
+    it "removes stale worker keys" do
+      test1 = Gru::WorkerManager.new(adapter1)
+      test2 = Gru::WorkerManager.new(adapter2)
+      test1.register_workers
+      test2.register_workers
+      expect(client.hgetall("GRU:default:default:global:max_workers").keys).to eq(['foo_worker'])
+    end
+  end
 end


### PR DESCRIPTION
Old keys are not removed and can build up over time as configurations
change.
