### PR TITLE
Add timeout for adjusting worker counts

### DIFF
--- a/lib/gru/adapters/redis_adapter.rb
+++ b/lib/gru/adapters/redis_adapter.rb
@@ -164,8 +164,8 @@ module Gru
       end
 
       def adjust_workers(worker,amount)
-        lock_key = "#{gru_key}:#{worker}"
-        if send_message(:setnx,lock_key,Time.now.to_i)
+        lock_key = "#{gru_key}:locks:#{worker}"
+        if send_message(:set,lock_key,Time.now.to_i, { nx: true, px: 10000 })
           send_message(:hincrby,host_workers_running_key,worker,amount)
           send_message(:hincrby,global_workers_running_key,worker,amount)
           send_message(:del,lock_key)

--- a/lib/gru/version.rb
+++ b/lib/gru/version.rb
@@ -1,3 +1,3 @@
 module Gru
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
There are some scenarios where bad things happen in redis between
setting the adjustment lock and removing it. This has caused the lock to
remain in place preventing further worker count adjustments for that
particular worker.

Bump Version
